### PR TITLE
1_apt-get_update.sh

### DIFF
--- a/environments/poc-cluster/node/build/1_apt-get_update.sh
+++ b/environments/poc-cluster/node/build/1_apt-get_update.sh
@@ -1,4 +1,4 @@
 #System Update
 
 apt-get update
-apt-get upgrade
+yes | apt-get upgrade


### PR DESCRIPTION
Hi, Kevin Graves from O'Reilly Media/Katacoda. I noticed the node for your custom enviroment `poc-cluster` wasn't building because the build was exiting waiting for a "yes" prompt. This should help the build finish by using `yes` to answer the prompt. 