### PR TITLE
prevent infinite `yes`{{execute}} response bug

### DIFF
--- a/conjur-k8s-secretless/sa-3.md
+++ b/conjur-k8s-secretless/sa-3.md
@@ -26,7 +26,7 @@ In your own environment, you may wish to add it in shell script file, e.g. `~/.b
 To initialize the client, execute:
 `conjur init --url https://conjur.demo.com:9443  --account default`{{execute}}
 
-Trust this certificate: `yes`{{execute}}
+Trust this certificate: `yes`{{execute HOST1}}
 
 ```
 Wrote certificate to /root/conjur-default.pem


### PR DESCRIPTION
Please consider this as a route of mitigating the issue reported on 10/17 (tracking ID KATACODA-240). It appears the `yes` command is being executed on both nodes and only ceases on the first node requesting certificate acceptance. Meanwhile, the second node receives endless `yes` output until the browser/socket falls over (screenshot of websocket activity attached below). This change ensures it is only executed in the correct node. For more information on this capability, we have [this reference scenario](https://katacoda.com/scenario-examples/scenarios/markdown-extensions).

<img width="2018" alt="Screen Shot 2020-10-21 at 5 20 38 PM" src="https://user-images.githubusercontent.com/21319/97044699-133d4100-153a-11eb-9afe-fa75fd81549e.png">
